### PR TITLE
Fix markdown formatting in Synthetic Control blog post

### DIFF
--- a/_posts/2024-01-11-Synthetic-Control-Goodreads-FT.md
+++ b/_posts/2024-01-11-Synthetic-Control-Goodreads-FT.md
@@ -125,8 +125,7 @@ thrown off the original model (see
 below).![](/assets/image2.png)
 
 To give a singular example of the results for a single treatment unit,
-below are three graphs of Branko Milanovic\'s new book [*[Visions of
-Inequality]{.underline}*](https://www.goodreads.com/book/stats?id=123831773),
+below are three graphs of Branko Milanovic\'s new book [*Visions of Inequality*](https://www.goodreads.com/book/stats?id=123831773),
 the goodreads data (with a dotted line added for treatment date), the
 actual versus the blue dotted synthetic control, and the gap.
 


### PR DESCRIPTION
## Summary
Cleaned up markdown formatting in the Synthetic Control Goodreads analysis blog post to improve readability and remove unnecessary HTML-style formatting.

## Key Changes
- Removed inline HTML `{.underline}` span formatting from the book title "Visions of Inequality"
- Simplified the markdown link syntax while preserving the hyperlink to the Goodreads book page
- The book title now uses standard markdown italic formatting (`*...*`) instead of mixed markdown and HTML

## Details
The change removes legacy HTML-style formatting that was embedded within the markdown link, making the source more maintainable and the rendered output cleaner. The link functionality and all content remain unchanged.

https://claude.ai/code/session_01LAoqnpV21c8LsPSTvoqkRd