### PR TITLE
Increase post container width from 45% to 90%

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -79,7 +79,7 @@ a:focus {
 }
 
 .post-div {
-  width: 45%;
+  width: 90%;
   margin-bottom: 1.5rem;
 }
 


### PR DESCRIPTION
## Summary
Updated the `.post-div` CSS class to use a wider layout, increasing the width from 45% to 90% of its container.

## Changes
- Modified `.post-div` width property from `45%` to `90%` in `public/css/custom.css`

## Details
This change expands the post container to utilize more horizontal space, likely improving content visibility and readability on the page. The post elements will now take up 90% of their parent container's width instead of the previous 45%.

https://claude.ai/code/session_016HXoETuGMJiUmzyaBxsnjY